### PR TITLE
[MINOR] Remove audio splitting and file-based synthesis

### DIFF
--- a/Echo/Components/Settings/AudioOptionsArea.swift
+++ b/Echo/Components/Settings/AudioOptionsArea.swift
@@ -9,21 +9,7 @@ import Foundation
 import SwiftUI
 
 
-struct DirectionPicker: View {
-    var labelText: String
-    @Binding var selection: AudioDirection
-    
-    var body: some View {
-        VStack(alignment: .leading) {
-            Text(labelText)
-            Picker(labelText, selection: $selection, content: {
-                Text("Left Channel", comment: "Label for picker of audio channels").tag(AudioDirection.left)
-                Text("Right Channel", comment: "Label for picker of audio channels").tag(AudioDirection.right)
-            })
-            .pickerStyle(.segmented)
-        }
-    }
-}
+// DirectionPicker removed - audio splitting functionality disabled
 
 struct AudioOptionsArea: View {
     @Environment(Settings.self) var settings: Settings
@@ -32,38 +18,18 @@ struct AudioOptionsArea: View {
         @Bindable var bindableSettings = settings
         Form {
             Section(content: {
-                Toggle(isOn: $bindableSettings.splitAudio) {
-                    Text("Directional Audio", comment: "Label for directional audio toggle")
-                }
-                if bindableSettings.splitAudio {
-                    DirectionPicker(
-                        labelText:
-                            String(
-                                localized: "Cue Voice Direction",
-                                comment: "Label for cue voice audio direction"
-                            ),
-                        selection: $bindableSettings.cueDirection
-                    )
-                    DirectionPicker(
-                        labelText:
-                            String(
-                                localized: "Speaking Voice Direction",
-                                comment: "Label for speaking voice audio direction"
-                            ),
-                        selection: $bindableSettings.speakDirection
-                    )
-                }
+                // Audio splitting functionality has been disabled
+                // All audio will be played through both channels (center)
+                Text("Audio Output", comment: "Label for audio output information")
+                    .foregroundStyle(.secondary)
+                Text("Both cue voice and speaking voice will be played through both audio channels.", comment: "Description of current audio behavior")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }, header: {
                 Text(
                     "Audio",
                     comment: "The label for the section about analytics"
                 )
-            }, footer: {
-                Text(
-                    """
-                    By default the cue voice and the speaking voice will be played out of the same audio device. If you would like them to be sent to different audio devices you can enable audio splitting and send each voice to either the left our right audio channel. You then have to use an audio splitter cable to direct that out.
-                    """,
-                comment: "A description of why audio splitting exists")
             })
         }
         .navigationTitle(

--- a/Echo/Models/Settings.swift
+++ b/Echo/Models/Settings.swift
@@ -22,9 +22,10 @@ class Settings {
     // Audio settings
     var cueVoice: Voice?
     var speakingVoice: Voice?
-    var splitAudio: Bool
-    var cueDirection: AudioDirection
-    var speakDirection: AudioDirection
+    // Audio splitting disabled - all audio plays through center channel
+    private var splitAudio: Bool = false // Always disabled
+    private var cueDirection: AudioDirection = .center // Always center
+    private var speakDirection: AudioDirection = .center // Always center
 
     // Scanning settings
     var scanning: Bool
@@ -80,6 +81,11 @@ class Settings {
     var messageBarBackgroundOpacity: Double = 1.0
     var messageBarFontName: String = "System"
     var messageBarFontSize: Int = 16
+
+    // Public getters for audio direction (always center since splitting is disabled)
+    var effectiveCueDirection: AudioDirection { return .center }
+    var effectiveSpeakDirection: AudioDirection { return .center }
+    var isAudioSplittingEnabled: Bool { return false }
     
     init(showOnboarding: Bool = true) {
         self.showOnboarding = showOnboarding
@@ -93,9 +99,10 @@ class Settings {
         // Initialize Audio settings
         self.cueVoice = nil
         self.speakingVoice = nil
+        // Audio splitting is disabled - properties are set to fixed values
         self.splitAudio = false
-        self.cueDirection = .left
-        self.speakDirection = .right
+        self.cueDirection = .center
+        self.speakDirection = .center
 
         // Initialize Scanning settings
         self.scanning = true

--- a/Echo/Observables/VoiceController.swift
+++ b/Echo/Observables/VoiceController.swift
@@ -96,7 +96,8 @@ class VoiceController: ObservableObject {
     
     func playFastCue(_ text: String, cb: (() -> Void)? = {}) {
         if let unwrappedSettings = settings {
-            let direction: AudioDirection = unwrappedSettings.splitAudio ? unwrappedSettings.cueDirection : .center
+            // Audio splitting disabled - always use center channel
+            let direction: AudioDirection = .center
 
             // Use existing cue voice or create a safe default using available voices
             let cueVoice: Voice
@@ -117,7 +118,8 @@ class VoiceController: ObservableObject {
     
     func playCue(_ text: String?, isFast: Bool = false, cb: (() -> Void)? = {}) {
         if let unwrappedSettings = settings {
-            let direction: AudioDirection = unwrappedSettings.splitAudio ? unwrappedSettings.cueDirection : .center
+            // Audio splitting disabled - always use center channel
+            let direction: AudioDirection = .center
 
             // Use existing cue voice or create a safe default using available voices
             let cueVoice: Voice
@@ -134,8 +136,8 @@ class VoiceController: ObservableObject {
     
     func playSpeaking(_ text: String, cb: (() -> Void)? = {}) {
         if let unwrappedSettings = settings {
-
-            let direction: AudioDirection = unwrappedSettings.splitAudio ? unwrappedSettings.speakDirection : .center
+            // Audio splitting disabled - always use center channel
+            let direction: AudioDirection = .center
 
             // Use existing speaking voice or create a safe default using available voices
             let speakingVoice: Voice


### PR DESCRIPTION
Audio splitting functionality has been disabled; all audio now plays through both channels (center). File-based speech synthesis and related AVAudioPlayer logic have been removed in favor of direct speech synthesis for faster and simpler output. UI and settings related to audio direction and splitting have been updated accordingly.