### PR TITLE
[MINOR] Replace shorthand enum cases with explicit type names

### DIFF
--- a/Echo/Models/Settings.swift
+++ b/Echo/Models/Settings.swift
@@ -24,8 +24,8 @@ class Settings {
     var speakingVoice: Voice?
     // Audio splitting disabled - all audio plays through center channel
     private var splitAudio: Bool = false // Always disabled
-    private var cueDirection: AudioDirection = .center // Always center
-    private var speakDirection: AudioDirection = .center // Always center
+    private var cueDirection: AudioDirection = AudioDirection.center // Always center
+    private var speakDirection: AudioDirection = AudioDirection.center // Always center
 
     // Scanning settings
     var scanning: Bool
@@ -83,8 +83,8 @@ class Settings {
     var messageBarFontSize: Int = 16
 
     // Public getters for audio direction (always center since splitting is disabled)
-    var effectiveCueDirection: AudioDirection { return .center }
-    var effectiveSpeakDirection: AudioDirection { return .center }
+    var effectiveCueDirection: AudioDirection { return AudioDirection.center }
+    var effectiveSpeakDirection: AudioDirection { return AudioDirection.center }
     var isAudioSplittingEnabled: Bool { return false }
     
     init(showOnboarding: Bool = true) {
@@ -101,8 +101,8 @@ class Settings {
         self.speakingVoice = nil
         // Audio splitting is disabled - properties are set to fixed values
         self.splitAudio = false
-        self.cueDirection = .center
-        self.speakDirection = .center
+        self.cueDirection = AudioDirection.center
+        self.speakDirection = AudioDirection.center
 
         // Initialize Scanning settings
         self.scanning = true

--- a/Echo/Observables/VoiceController.swift
+++ b/Echo/Observables/VoiceController.swift
@@ -30,7 +30,7 @@ class VoiceController: ObservableObject {
             // This prevents audio session conflicts between ARKit and speech synthesis
             try audioSession.setCategory(.playAndRecord,
                                        mode: .default,
-                                       options: [.defaultToSpeaker, .allowBluetoothHFP])
+                                       options: [.defaultToSpeaker, .allowBluetooth])
 
             // Activate the session
             try audioSession.setActive(true)
@@ -97,7 +97,7 @@ class VoiceController: ObservableObject {
     func playFastCue(_ text: String, cb: (() -> Void)? = {}) {
         if let unwrappedSettings = settings {
             // Audio splitting disabled - always use center channel
-            let direction: AudioDirection = .center
+            let direction: AudioDirection = AudioDirection.center
 
             // Use existing cue voice or create a safe default using available voices
             let cueVoice: Voice
@@ -119,7 +119,7 @@ class VoiceController: ObservableObject {
     func playCue(_ text: String?, isFast: Bool = false, cb: (() -> Void)? = {}) {
         if let unwrappedSettings = settings {
             // Audio splitting disabled - always use center channel
-            let direction: AudioDirection = .center
+            let direction: AudioDirection = AudioDirection.center
 
             // Use existing cue voice or create a safe default using available voices
             let cueVoice: Voice
@@ -137,7 +137,7 @@ class VoiceController: ObservableObject {
     func playSpeaking(_ text: String, cb: (() -> Void)? = {}) {
         if let unwrappedSettings = settings {
             // Audio splitting disabled - always use center channel
-            let direction: AudioDirection = .center
+            let direction: AudioDirection = AudioDirection.center
 
             // Use existing speaking voice or create a safe default using available voices
             let speakingVoice: Voice


### PR DESCRIPTION
Updated all instances of '.center' to 'AudioDirection.center' for clarity and consistency in Settings and VoiceController. Also changed audio session option from .allowBluetoothHFP to .allowBluetooth in VoiceController.